### PR TITLE
feat: added support dfsp-id-map translations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ CACHE_HOST=localhost
 
 # Redis Port
 CACHE_PORT=6379
+
+# DFSP EXT to INT ID Map - used to convert external OUTBOUND/INBOUND DFSP-IDs from internal Mojaloop IDs. Note: translation mapping will only occur if a match is found, otherwise the DFSP ID will be mapped as-is!
+DFSP_ID_MAP={ "outbound": { "EXTERNAL_ID_DFSP1": "INTERNAL_ID_DFSP1", "EXTERNAL_ID_DFSP2": "INTERNAL_ID_DFSP2" }, "inbound": { "INTERNAL_ID_DFSP1": "EXTERNAL_ID_DFSP1", "INTERNAL_ID_DFSP2": "EXTERNAL_ID_DFSP2" } }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iso20022-core-connector",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iso20022-core-connector",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ISO20022 Core Connector for Mojaloop",
   "main": "build/index.js",
   "scripts": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,8 +25,9 @@ export interface IServiceConfig {
     logger?: Logger.Logger,
     xmlOptions: IXMLOptions,
     templatesPath: string
-    cache: CacheConfig,
+    cache: ICacheConfig,
     callbackTimeout: number,
+    dfspIdMap?: DfspIdMapType,
 }
 
 export interface IXMLOptions {
@@ -61,11 +62,20 @@ const xmlOptions: IXMLOptions = {
     arrayMode: false,
 };
 
-export interface CacheConfig {
+export interface ICacheConfig {
     host: string,
     port: number,
     enabledTestFeatures?: boolean,
 }
+
+export type DfspIdMapType = {
+    outbound: {
+        [key: string]: string,
+    },
+    inbound: {
+        [key: string]: string,
+    },
+};
 
 export const Config: IServiceConfig = {
     port: env.get('LISTEN_PORT').default('3003').asPortNumber(),
@@ -80,4 +90,5 @@ export const Config: IServiceConfig = {
         enabledTestFeatures: env.get('CACHE_ENABLED_TEST_FEATURES').asBool() || false,
     },
     callbackTimeout: env.get('CALLBACK_TIMEOUT').default(30).asInt(),
+    dfspIdMap: env.get('DFSP_ID_MAP').default({}).asJsonObject() as DfspIdMapType,
 };

--- a/src/handlers/Inbound/index.ts
+++ b/src/handlers/Inbound/index.ts
@@ -110,7 +110,7 @@ const postTransfers = async (ctx: ApiContext): Promise<void> => new Promise(asyn
     let pacsState: IPacsState | undefined;
 
     try {
-        const postTransfersBodyPacs008 = postTransferBodyToPacs008(payload);
+        const postTransfersBodyPacs008 = postTransferBodyToPacs008(payload, ctx.state?.conf?.dfspIdMap);
         const pacs008 = XML.fromXml(postTransfersBodyPacs008) as IPacs008;
 
         // map to

--- a/src/handlers/Outbound/camt003Handler.ts
+++ b/src/handlers/Outbound/camt003Handler.ts
@@ -54,7 +54,7 @@ export default async (ctx: ApiContext): Promise<void> => {
 
         ctx.state.logger.log(res.data);
         ctx.response.type = 'application/xml';
-        ctx.response.body = partiesByIdResponseToCamt004(res.data);
+        ctx.response.body = partiesByIdResponseToCamt004(res.data, ctx.state?.conf?.dfspIdMap);
         ctx.response.status = 200;
     } catch (e: unknown) {
         handleError(e as Error, ctx);

--- a/src/handlers/Outbound/pacs008Handler.ts
+++ b/src/handlers/Outbound/pacs008Handler.ts
@@ -69,7 +69,7 @@ export const processTransferRequest = async (ctx: ApiContext): Promise<void> => 
     const outboundRequester = new OutboundRequester(outboundRequesterOps);
 
     try {
-        const postQuotesBody = pacs008ToPostQuotesBody(ctx.request.body as IPacs008);
+        const postQuotesBody = pacs008ToPostQuotesBody(ctx.request.body as IPacs008, ctx.state?.conf?.dfspIdMap);
 
         // map to
         pacsState = {};


### PR DESCRIPTION
- added DFSP_ID_MAP env var, which contains a map for inbound/outbound transformations for external & internal DFSP IDs
- updated outbound PACS008 and CAMT003 API Handlers to support the DFSP_ID_MAP
- updated inbound POST /transfers to support the DFSP_ID_MAP

Note: translation mapping will only occur if a match is found, otherwise the DFSP ID will be mapped as-is!